### PR TITLE
Retain fragments when re-create activity

### DIFF
--- a/app/src/main/java/io/viewpoint/moviedatabase/platform/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/viewpoint/moviedatabase/platform/ui/main/MainActivity.kt
@@ -9,13 +9,14 @@ import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
 import io.viewpoint.moviedatabase.R
 import io.viewpoint.moviedatabase.databinding.ActivityMainBinding
-import io.viewpoint.moviedatabase.ui.setting.SettingFragment
 import io.viewpoint.moviedatabase.ui.home.HomeFragment
+import io.viewpoint.moviedatabase.ui.search.MovieSearchFragment
+import io.viewpoint.moviedatabase.ui.setting.SettingFragment
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private val binding: ActivityMainBinding by lazy {
-        DataBindingUtil.setContentView<ActivityMainBinding>(this, R.layout.activity_main)
+        DataBindingUtil.setContentView(this, R.layout.activity_main)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,14 +25,17 @@ class MainActivity : AppCompatActivity() {
         binding.bottomNavigation.setOnNavigationItemSelectedListener {
             when (it.itemId) {
                 R.id.home_menu -> replaceFragment<HomeFragment>(HomeFragment.TAG)
-                R.id.movie_search_menu -> replaceFragment<io.viewpoint.moviedatabase.ui.search.MovieSearchFragment>(
-                    io.viewpoint.moviedatabase.ui.search.MovieSearchFragment.TAG)
-                R.id.setting_menu -> replaceFragment<io.viewpoint.moviedatabase.ui.setting.SettingFragment>(
-                    io.viewpoint.moviedatabase.ui.setting.SettingFragment.TAG)
+                R.id.movie_search_menu -> replaceFragment<MovieSearchFragment>(MovieSearchFragment.TAG)
+                R.id.setting_menu -> replaceFragment<SettingFragment>(SettingFragment.TAG)
                 else -> false
             }
         }
-        binding.bottomNavigation.selectedItemId = MainTab.HOME.itemId
+        binding.bottomNavigation.selectedItemId = savedInstanceState?.getInt(KEY_SELECTED_TAB)
+            ?.let {
+                MainTab.from(it)
+            }
+            ?.itemId
+            ?: MainTab.HOME.itemId
     }
 
     private inline fun <reified T : Fragment> replaceFragment(tag: String): Boolean {
@@ -53,5 +57,14 @@ class MainActivity : AppCompatActivity() {
             }
         }
         return true
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(KEY_SELECTED_TAB, binding.bottomNavigation.selectedItemId)
+    }
+
+    companion object {
+        private const val KEY_SELECTED_TAB = "selectedTab"
     }
 }

--- a/app/src/main/java/io/viewpoint/moviedatabase/platform/ui/main/MainTab.kt
+++ b/app/src/main/java/io/viewpoint/moviedatabase/platform/ui/main/MainTab.kt
@@ -1,18 +1,21 @@
 package io.viewpoint.moviedatabase.platform.ui.main
 
 import io.viewpoint.moviedatabase.R
-import io.viewpoint.moviedatabase.ui.setting.SettingFragment
 import io.viewpoint.moviedatabase.ui.home.HomeFragment
+import io.viewpoint.moviedatabase.ui.search.MovieSearchFragment
+import io.viewpoint.moviedatabase.ui.setting.SettingFragment
 
 enum class MainTab(
     val itemId: Int,
     val tag: String
 ) {
     HOME(R.id.home_menu, HomeFragment.TAG),
-    MOVIE_SEARCH(R.id.movie_search_menu, io.viewpoint.moviedatabase.ui.search.MovieSearchFragment.TAG),
-    SETTING(R.id.setting_menu, io.viewpoint.moviedatabase.ui.setting.SettingFragment.TAG);
+    MOVIE_SEARCH(R.id.movie_search_menu, MovieSearchFragment.TAG),
+    SETTING(R.id.setting_menu, SettingFragment.TAG);
 
-    companion object
+    companion object {
+        fun from(itemId: Int): MainTab? = values().firstOrNull { it.itemId == itemId }
+    }
 }
 
 fun MainTab.Companion.otherTab(exceptTag: String): Sequence<MainTab> =

--- a/feature-search/src/main/java/io/viewpoint/moviedatabase/ui/search/viewmodel/MovieSearchViewModel.kt
+++ b/feature-search/src/main/java/io/viewpoint/moviedatabase/ui/search/viewmodel/MovieSearchViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import io.viewpoint.moviedatabase.domain.PreferencesKeys
 import io.viewpoint.moviedatabase.domain.preferences.PreferencesService
 import io.viewpoint.moviedatabase.domain.preferences.addValue
@@ -30,7 +31,7 @@ class MovieSearchViewModel @ViewModelInject constructor(
 
     val keyword: MutableLiveData<String> = MutableLiveData()
 
-    val results: LiveData<PagingData<SearchResultModel>> = _results
+    val results: LiveData<PagingData<SearchResultModel>> = _results.cachedIn(this)
 
     val resultCount = MutableLiveData<Int>()
 


### PR DESCRIPTION
## Changed
- Retain selected tab in bottom navigation when recreate activity
- Fix the crash when was rotated in the search screen