### PR TITLE
Separate MovieApi to MovieApi, and MovieDetailApi

### DIFF
--- a/api/src/main/java/io/viewpoint/moviedatabase/api/MovieApi.kt
+++ b/api/src/main/java/io/viewpoint/moviedatabase/api/MovieApi.kt
@@ -1,16 +1,10 @@
 package io.viewpoint.moviedatabase.api
 
 import arrow.fx.IO
-import io.viewpoint.moviedatabase.model.api.CreditsResponse
-import io.viewpoint.moviedatabase.model.api.MovieDetail
 import io.viewpoint.moviedatabase.model.api.MovieListResponse
 import retrofit2.http.GET
-import retrofit2.http.Path
 
 interface MovieApi {
-    @GET("movie/{id}")
-    fun getMovieDetail(@Path("id") id: Int): IO<MovieDetail>
-
     @GET("movie/popular")
     fun getPopular(): IO<MovieListResponse>
 
@@ -22,7 +16,4 @@ interface MovieApi {
 
     @GET("movie/top_rated")
     fun getTopRated(): IO<MovieListResponse>
-
-    @GET("movie/{id}/credits")
-    fun getMovieCredits(@Path("id") id: Int): IO<CreditsResponse>
 }

--- a/api/src/main/java/io/viewpoint/moviedatabase/api/MovieDetailApi.kt
+++ b/api/src/main/java/io/viewpoint/moviedatabase/api/MovieDetailApi.kt
@@ -1,0 +1,15 @@
+package io.viewpoint.moviedatabase.api
+
+import arrow.fx.IO
+import io.viewpoint.moviedatabase.model.api.CreditsResponse
+import io.viewpoint.moviedatabase.model.api.MovieDetail
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface MovieDetailApi {
+    @GET("movie/{id}")
+    fun getMovieDetail(@Path("id") id: Int): IO<MovieDetail>
+
+    @GET("movie/{id}/credits")
+    fun getMovieCredits(@Path("id") id: Int): IO<CreditsResponse>
+}

--- a/app/src/main/java/io/viewpoint/moviedatabase/di/ApiModule.kt
+++ b/app/src/main/java/io/viewpoint/moviedatabase/di/ApiModule.kt
@@ -5,10 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.viewpoint.moviedatabase.BuildConfig
-import io.viewpoint.moviedatabase.api.ConfigurationApi
-import io.viewpoint.moviedatabase.api.MovieApi
-import io.viewpoint.moviedatabase.api.MovieDatabaseApi
-import io.viewpoint.moviedatabase.api.SearchApi
+import io.viewpoint.moviedatabase.api.*
 import io.viewpoint.moviedatabase.platform.util.Flippers
 import timber.log.Timber
 import javax.inject.Singleton
@@ -42,6 +39,10 @@ class ApiModule {
     @Provides
     @Singleton
     fun movieApi(movieDatabaseApi: MovieDatabaseApi): MovieApi = movieDatabaseApi.get()
+
+    @Provides
+    @Singleton
+    fun movieDetailApi(movieDatabaseApi: MovieDatabaseApi): MovieDetailApi = movieDatabaseApi.get()
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/viewpoint/moviedatabase/di/RepositoryModule.kt
+++ b/app/src/main/java/io/viewpoint/moviedatabase/di/RepositoryModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import io.viewpoint.moviedatabase.api.MovieApi
+import io.viewpoint.moviedatabase.api.MovieDetailApi
 import io.viewpoint.moviedatabase.domain.repository.*
 import io.viewpoint.moviedatabase.platform.external.AppDatabase
 import javax.inject.Singleton
@@ -27,6 +27,12 @@ abstract class RepositoryModule {
 
     @Binds
     @Singleton
+    abstract fun movieDetailRepository(
+        repository: MovieDatabaseMovieDetailRepository
+    ): MovieDetailRepository
+
+    @Binds
+    @Singleton
     abstract fun searchRepository(
         repository: MovieDatabaseSearchRepository
     ): SearchRepository
@@ -37,9 +43,9 @@ abstract class RepositoryModule {
         @Provides
         @Singleton
         fun wantToSeeRepository(
-            movieApi: MovieApi,
+            movieDetailApi: MovieDetailApi,
             database: AppDatabase
         ): WantToSeeRepository =
-            MovieDatabaseWantToSeeRepository(movieApi, database.wantToSeeDao())
+            MovieDatabaseWantToSeeRepository(movieDetailApi, database.wantToSeeDao())
     }
 }

--- a/app/src/test/java/io/viewpoint/moviedatabase/viewmodel/search/MovieSearchResultDetailViewModelTest.kt
+++ b/app/src/test/java/io/viewpoint/moviedatabase/viewmodel/search/MovieSearchResultDetailViewModelTest.kt
@@ -2,12 +2,14 @@ package io.viewpoint.moviedatabase.viewmodel.search
 
 import io.viewpoint.moviedatabase.domain.CreditModelMapper
 import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseConfigurationRepository
+import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseMovieDetailRepository
 import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseMovieRepository
 import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseWantToSeeRepository
 import io.viewpoint.moviedatabase.domain.search.SearchResultMapperProvider
 import io.viewpoint.moviedatabase.test.TestBase
 import io.viewpoint.moviedatabase.test.mock.TestConfigurationApi
 import io.viewpoint.moviedatabase.test.mock.TestMovieApi
+import io.viewpoint.moviedatabase.test.mock.TestMovieDetailApi
 import io.viewpoint.moviedatabase.test.mock.TestWantToSeeDao
 import io.viewpoint.moviedatabase.ui.search.viewmodel.MovieSearchResultDetailViewModel
 import kotlinx.coroutines.runBlocking
@@ -22,17 +24,19 @@ class MovieSearchResultDetailViewModelTest : TestBase() {
     private val creditMapper =
         CreditModelMapper(MovieDatabaseConfigurationRepository(TestConfigurationApi()))
     private val movieApi = TestMovieApi()
+    private val movieDetailApi = TestMovieDetailApi()
     private val repository = MovieDatabaseWantToSeeRepository(
-        movieApi,
+        movieDetailApi,
         TestWantToSeeDao()
     )
     private val movieRepository = MovieDatabaseMovieRepository(movieApi)
+    private val movieDetailRepository = MovieDatabaseMovieDetailRepository(movieDetailApi)
     private lateinit var vm: MovieSearchResultDetailViewModel
 
     @Before
     fun setUp() {
         vm = MovieSearchResultDetailViewModel(
-            movieRepository = movieRepository,
+            movieDetailRepository = movieDetailRepository,
             wantToSeeRepository = repository,
             resultMapperProvider = mapperProvider,
             creditModelMapper = creditMapper

--- a/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDatabaseMovieDetailRepository.kt
+++ b/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDatabaseMovieDetailRepository.kt
@@ -1,0 +1,26 @@
+package io.viewpoint.moviedatabase.domain.repository
+
+import arrow.core.getOrElse
+import io.viewpoint.moviedatabase.api.MovieDetailApi
+import io.viewpoint.moviedatabase.model.api.Credit
+import io.viewpoint.moviedatabase.model.api.MovieDetail
+import javax.inject.Inject
+
+class MovieDatabaseMovieDetailRepository @Inject constructor(
+    private val movieDetailApi: MovieDetailApi
+) : MovieDetailRepository {
+    override suspend fun getMovieDetail(movieId: Int): MovieDetail? =
+        movieDetailApi.getMovieDetail(movieId)
+            .attempt()
+            .suspended()
+            .getOrElse { null }
+
+    override suspend fun getCredits(movieId: Int): List<Credit> =
+        movieDetailApi.getMovieCredits(movieId)
+            .attempt()
+            .suspended()
+            .map {
+                it.cast + it.crew
+            }
+            .getOrElse { emptyList() }
+}

--- a/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDatabaseMovieRepository.kt
+++ b/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDatabaseMovieRepository.kt
@@ -2,20 +2,12 @@ package io.viewpoint.moviedatabase.domain.repository
 
 import arrow.core.getOrElse
 import io.viewpoint.moviedatabase.api.MovieApi
-import io.viewpoint.moviedatabase.model.api.Credit
 import io.viewpoint.moviedatabase.model.api.Movie
-import io.viewpoint.moviedatabase.model.api.MovieDetail
 import javax.inject.Inject
 
 class MovieDatabaseMovieRepository @Inject constructor(
     private val movieApi: MovieApi
 ) : MovieRepository {
-    override suspend fun getMovieDetail(movieId: Int): MovieDetail? =
-        movieApi.getMovieDetail(movieId)
-            .attempt()
-            .suspended()
-            .getOrElse { null }
-
     override suspend fun getPopular(): List<Movie> = movieApi.getPopular()
         .attempt()
         .suspended()
@@ -45,14 +37,6 @@ class MovieDatabaseMovieRepository @Inject constructor(
         .suspended()
         .map {
             it.results
-        }
-        .getOrElse { emptyList() }
-
-    override suspend fun getCredits(movieId: Int): List<Credit> = movieApi.getMovieCredits(movieId)
-        .attempt()
-        .suspended()
-        .map {
-            it.cast + it.crew
         }
         .getOrElse { emptyList() }
 }

--- a/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDatabaseWantToSeeRepository.kt
+++ b/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDatabaseWantToSeeRepository.kt
@@ -2,14 +2,14 @@ package io.viewpoint.moviedatabase.domain.repository
 
 import arrow.fx.IO
 import arrow.fx.extensions.fx
-import io.viewpoint.moviedatabase.api.MovieApi
+import io.viewpoint.moviedatabase.api.MovieDetailApi
 import io.viewpoint.moviedatabase.domain.repository.dao.WantToSeeDao
 import io.viewpoint.moviedatabase.domain.repository.entity.WantToSeeMovieEntity
 import io.viewpoint.moviedatabase.model.api.MovieDetail
 import javax.inject.Inject
 
 class MovieDatabaseWantToSeeRepository @Inject constructor(
-    private val movieApi: MovieApi,
+    private val movieDetailApi: MovieDetailApi,
     private val dao: WantToSeeDao
 ) : WantToSeeRepository {
     override fun hasWantToSeeMovie(id: Int): IO<Boolean> = IO.fx {
@@ -27,7 +27,7 @@ class MovieDatabaseWantToSeeRepository @Inject constructor(
         }
 
         !ids.map { id ->
-            movieApi.getMovieDetail(id)
+            movieDetailApi.getMovieDetail(id)
         }.parSequence()
     }
 

--- a/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDetailRepository.kt
+++ b/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieDetailRepository.kt
@@ -1,0 +1,10 @@
+package io.viewpoint.moviedatabase.domain.repository
+
+import io.viewpoint.moviedatabase.model.api.Credit
+import io.viewpoint.moviedatabase.model.api.MovieDetail
+
+interface MovieDetailRepository {
+    suspend fun getMovieDetail(movieId: Int): MovieDetail?
+
+    suspend fun getCredits(movieId: Int): List<Credit>
+}

--- a/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/io/viewpoint/moviedatabase/domain/repository/MovieRepository.kt
@@ -1,12 +1,8 @@
 package io.viewpoint.moviedatabase.domain.repository
 
-import io.viewpoint.moviedatabase.model.api.Credit
 import io.viewpoint.moviedatabase.model.api.Movie
-import io.viewpoint.moviedatabase.model.api.MovieDetail
 
 interface MovieRepository {
-    suspend fun getMovieDetail(movieId: Int): MovieDetail?
-
     suspend fun getPopular(): List<Movie>
 
     suspend fun getNowPlayings(): List<Movie>
@@ -14,6 +10,4 @@ interface MovieRepository {
     suspend fun getUpcoming(): List<Movie>
 
     suspend fun getTopRated(): List<Movie>
-
-    suspend fun getCredits(movieId: Int): List<Credit>
 }

--- a/feature-home/src/test/java/io/viewpoint/moviedatabase/viewmodel/MainViewModelTest.kt
+++ b/feature-home/src/test/java/io/viewpoint/moviedatabase/viewmodel/MainViewModelTest.kt
@@ -9,10 +9,7 @@ import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseConfigurationRe
 import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseMovieRepository
 import io.viewpoint.moviedatabase.domain.repository.MovieDatabaseWantToSeeRepository
 import io.viewpoint.moviedatabase.test.TestBase
-import io.viewpoint.moviedatabase.test.mock.TestConfigurationApi
-import io.viewpoint.moviedatabase.test.mock.TestMovieApi
-import io.viewpoint.moviedatabase.test.mock.TestPreferencesService
-import io.viewpoint.moviedatabase.test.mock.TestWantToSeeDao
+import io.viewpoint.moviedatabase.test.mock.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
@@ -33,7 +30,7 @@ class MainViewModelTest : TestBase() {
                 TestConfigurationApi()
             ),
             MovieDatabaseWantToSeeRepository(
-                TestMovieApi(),
+                TestMovieDetailApi(),
                 TestWantToSeeDao()
             ),
             MovieDatabaseMovieRepository(

--- a/feature-search/src/main/java/io/viewpoint/moviedatabase/ui/search/viewmodel/MovieSearchResultDetailViewModel.kt
+++ b/feature-search/src/main/java/io/viewpoint/moviedatabase/ui/search/viewmodel/MovieSearchResultDetailViewModel.kt
@@ -8,7 +8,7 @@ import arrow.core.Either
 import arrow.core.getOrElse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.viewpoint.moviedatabase.domain.CreditModelMapper
-import io.viewpoint.moviedatabase.domain.repository.MovieRepository
+import io.viewpoint.moviedatabase.domain.repository.MovieDetailRepository
 import io.viewpoint.moviedatabase.domain.repository.WantToSeeRepository
 import io.viewpoint.moviedatabase.domain.search.SearchResultMapperProvider
 import io.viewpoint.moviedatabase.model.api.MovieDetail
@@ -20,7 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MovieSearchResultDetailViewModel @Inject constructor(
-    private val movieRepository: MovieRepository,
+    private val movieDetailRepository: MovieDetailRepository,
     private val wantToSeeRepository: WantToSeeRepository,
     private val resultMapperProvider: SearchResultMapperProvider,
     private val creditModelMapper: CreditModelMapper
@@ -67,7 +67,7 @@ class MovieSearchResultDetailViewModel @Inject constructor(
     }
 
     suspend fun loadWithMovieId(movieId: Int): SearchResultModel? {
-        val result = movieRepository.getMovieDetail(movieId)
+        val result = movieDetailRepository.getMovieDetail(movieId)
             ?.let {
                 fillDetailData(it)
                 resultMapperProvider.mapperFromMovieDetail.map(it)
@@ -86,7 +86,7 @@ class MovieSearchResultDetailViewModel @Inject constructor(
             .getOrElse { false }
 
         if (_genres.value?.isEmpty() == true) {
-            movieRepository.getMovieDetail(result.id)
+            movieDetailRepository.getMovieDetail(result.id)
                 ?.let {
                     fillDetailData(it)
                 }
@@ -98,7 +98,7 @@ class MovieSearchResultDetailViewModel @Inject constructor(
         _countries.value = movieDetail.production_countries.map { it.iso_3166_1 }
 
         // TODO call parallel with a move detail
-        _credits.value = movieRepository.getCredits(movieDetail.id)
+        _credits.value = movieDetailRepository.getCredits(movieDetail.id)
             .map {
                 creditModelMapper.map(it)
             }

--- a/test-base/src/main/java/io/viewpoint/moviedatabase/test/mock/TestMovieApi.kt
+++ b/test-base/src/main/java/io/viewpoint/moviedatabase/test/mock/TestMovieApi.kt
@@ -3,20 +3,9 @@ package io.viewpoint.moviedatabase.test.mock
 import arrow.fx.IO
 import arrow.fx.extensions.fx
 import io.viewpoint.moviedatabase.api.MovieApi
-import io.viewpoint.moviedatabase.model.api.CreditsResponse
-import io.viewpoint.moviedatabase.model.api.MovieDetail
 import io.viewpoint.moviedatabase.model.api.MovieListResponse
 
 class TestMovieApi : MovieApi {
-    override fun getMovieDetail(id: Int): IO<MovieDetail> = IO.fx {
-        !effect {
-            io.viewpoint.moviedatabase.test.ResponseReader.jsonFromFileAsync(
-                "responses/movie-detail.json",
-                io.viewpoint.moviedatabase.test.MoshiReader.moshi.adapter(MovieDetail::class.java)
-            )
-        }
-    }
-
     override fun getPopular(): IO<MovieListResponse> = IO.fx {
         !effect {
             io.viewpoint.moviedatabase.test.ResponseReader.jsonFromFileAsync(
@@ -49,15 +38,6 @@ class TestMovieApi : MovieApi {
             io.viewpoint.moviedatabase.test.ResponseReader.jsonFromFileAsync(
                 "responses/movie-list-results.json",
                 io.viewpoint.moviedatabase.test.MoshiReader.moshi.adapter(MovieListResponse::class.java)
-            )
-        }
-    }
-
-    override fun getMovieCredits(id: Int): IO<CreditsResponse> = IO.fx {
-        !effect {
-            io.viewpoint.moviedatabase.test.ResponseReader.jsonFromFileAsync(
-                "responses/movie-credits.json",
-                io.viewpoint.moviedatabase.test.MoshiReader.moshi.adapter(CreditsResponse::class.java)
             )
         }
     }

--- a/test-base/src/main/java/io/viewpoint/moviedatabase/test/mock/TestMovieDetailApi.kt
+++ b/test-base/src/main/java/io/viewpoint/moviedatabase/test/mock/TestMovieDetailApi.kt
@@ -1,0 +1,29 @@
+package io.viewpoint.moviedatabase.test.mock
+
+import arrow.fx.IO
+import arrow.fx.extensions.fx
+import io.viewpoint.moviedatabase.api.MovieDetailApi
+import io.viewpoint.moviedatabase.model.api.CreditsResponse
+import io.viewpoint.moviedatabase.model.api.MovieDetail
+import io.viewpoint.moviedatabase.test.MoshiReader
+import io.viewpoint.moviedatabase.test.ResponseReader
+
+class TestMovieDetailApi : MovieDetailApi {
+    override fun getMovieDetail(id: Int): IO<MovieDetail> = IO.fx {
+        !effect {
+            ResponseReader.jsonFromFileAsync(
+                "responses/movie-detail.json",
+                MoshiReader.moshi.adapter(MovieDetail::class.java)
+            )
+        }
+    }
+
+    override fun getMovieCredits(id: Int): IO<CreditsResponse> = IO.fx {
+        !effect {
+            ResponseReader.jsonFromFileAsync(
+                "responses/movie-credits.json",
+                MoshiReader.moshi.adapter(CreditsResponse::class.java)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Changed
- Separate MovieApi to MovieApi, and MovieDetailApi
    - Need to separate in order to add more API without increasing methods in MovieApi interface.